### PR TITLE
Fixed bug causing space soccer to spam sfx when starting in the middle of it.

### DIFF
--- a/Assets/Resources/Games/spaceSoccer.prefab
+++ b/Assets/Resources/Games/spaceSoccer.prefab
@@ -1386,9 +1386,9 @@ MonoBehaviour:
     perfect: 0
     late: 0
     createBeat: 0
-  isEligible: 0
   eligibleHitsList: []
   aceTimes: 0
+  isEligible: 0
   canKick: 0
   canHighKick: 0
   kickLeft: 0
@@ -2004,7 +2004,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6448989353494316845
 Transform:
   m_ObjectHideFlags: 0
@@ -2044,9 +2044,10 @@ MonoBehaviour:
   kickCurve: {fileID: 1507665286932590801}
   highKickCurve: {fileID: 5471456891558289981}
   toeCurve: {fileID: 8336007186072323660}
-  dispensedBeat: 0
-  dispensing: 0
-  hitTimes: 0
+  startBeat: 0
+  state: 0
+  nextAnimBeat: 0
+  highKickSwing: 0
   canKick: 0
 --- !u!1 &4365805729759623217
 GameObject:
@@ -3886,9 +3887,9 @@ MonoBehaviour:
     perfect: 0
     late: 0
     createBeat: 0
-  isEligible: 0
   eligibleHitsList: []
   aceTimes: 0
+  isEligible: 0
   canKick: 0
   canHighKick: 0
   kickLeft: 0

--- a/Assets/Scripts/Games/PlayerActionObject.cs
+++ b/Assets/Scripts/Games/PlayerActionObject.cs
@@ -11,13 +11,13 @@ namespace RhythmHeavenMania.Games
         public bool inList = false;
         public int lastState;
         public Minigame.Eligible state = new Minigame.Eligible();
-        public bool isEligible;
 
         public List<Minigame.Eligible> eligibleHitsList = new List<Minigame.Eligible>();
 
-        public int aceTimes;
-
-        private bool autoPlayEnabledOnStart;
+        //the variables below seem to be mostly unused (they are never used in any meaningful way)
+        public int aceTimes; //always set to 0 no matter what (also, the one time it's used doesn't seem to make sense)
+        public bool isEligible; //value never used for anything
+        private bool autoPlayEnabledOnStart; //value never used for anything
 
         public void PlayerActionInit(GameObject g, float createBeat)
         {
@@ -31,7 +31,7 @@ namespace RhythmHeavenMania.Games
         {
             if (aceTimes == 0)
             {
-                if (GameManager.instance.autoplay && normalizedBeat > 0.99f || autoPlay && normalizedBeat > 0.99f)
+                if ((GameManager.instance.autoplay || autoPlay) && normalizedBeat > 0.99f)
                 {
                     OnAce();
                     if (!autoPlay)

--- a/Assets/Scripts/Games/SpaceSoccer/Ball.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Ball.cs
@@ -27,7 +27,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
         public float nextAnimBeat;
         public float highKickSwing = 0f;
         private float lastSpriteRot;
-        public bool canKick;
+        public bool canKick; //unused
         private bool lastKickLeft;
 
         public void Init(Kicker kicker, float dispensedBeat)
@@ -39,7 +39,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
             if(currentBeat - dispensedBeat < 2f) //check if ball is currently being dispensed (should only be false if starting in the middle of the remix)
             {
-                Debug.Log("Dispensing");
+                //Debug.Log("Dispensing");
                 state = State.Dispensing;
                 startBeat = dispensedBeat;
                 nextAnimBeat = startBeat + GetAnimLength(State.Dispensing);
@@ -74,7 +74,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                 }
                 if (highKicks[i].beat > currentBeat)
                 {
-                    Debug.Log("Setting state to kicked");
+                    //Debug.Log("Setting state to kicked");
                     state = State.Kicked;
                     float relativeBeat = currentBeat - dispensedBeat;
                     startBeat = dispensedBeat + (int)(relativeBeat - 0.1); //this makes the startBeat be for the kick that is currently in progress, but it won't play the kicker's animation for that kick. the -0.1 makes it so that if playback is started right when the kicker kicks, it still plays the kicker's animation.
@@ -87,7 +87,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                     highKickSwing = highKicks[i].swing;
                     if (highKicks[i].beat + GetAnimLength(State.HighKicked) > currentBeat)
                     {
-                        Debug.Log("Setting state to high kick");
+                        //Debug.Log("Setting state to high kick");
                         state = State.HighKicked;
                         float relativeBeat = highKicks[i].beat - dispensedBeat;
                         startBeat = dispensedBeat + Mathf.Ceil(relativeBeat); //there is a chance this makes startBeat later than the current beat, but it shouldn't matter too much. It would only happen if the user places the high kicks incorrectly.
@@ -97,7 +97,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                     }
                     else
                     {
-                        Debug.Log("Setting state to toe");
+                        //Debug.Log("Setting state to toe");
                         state = State.Toe;
                         float relativeBeat = Mathf.Ceil(highKicks[i].beat - dispensedBeat) + GetAnimLength(State.HighKicked); //there is a chance this makes startBeat later than the current beat, but it shouldn't matter too much. It would only happen if the user places the high kicks incorrectly.
                         startBeat = dispensedBeat + relativeBeat;
@@ -107,15 +107,16 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                     }
                 }
             }
-            if(state == State.Dispensing) //if the for loop didn't set the state
+            if(state == 0) //if the for loop didn't set the state
             {
-                Debug.Log("Defaulting to kicked state");
+                //Debug.Log("Defaulting to kicked state");
                 state = State.Kicked;
                 float relativeBeat = currentBeat - dispensedBeat;
                 startBeat = dispensedBeat + (int)(relativeBeat - 0.1); //this makes the startBeat be for the kick that is currently in progress, but it won't play the kicker's animation for that kick. the -0.1 makes it so that if playback is started right when the kicker kicks, it still plays the kicker's animation.
                 nextAnimBeat = startBeat + GetAnimLength(State.Kicked);
                 kicker.kickTimes = (int)(relativeBeat - 0.1) - numHighKicks - 1;
             }
+            Update(); //make sure the ball is in the right place
         }
 
         public void Kick(bool player)
@@ -177,7 +178,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         private void Update()
         {
-            switch (state)
+            switch (state) //handle animations
             {
                 case State.Dispensing:
                     {

--- a/Assets/Scripts/Games/SpaceSoccer/Ball.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Ball.cs
@@ -9,6 +9,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 {
     public class Ball : MonoBehaviour
     {
+        public enum State { Dispensing, Kicked, HighKicked, Toe };
         [Header("Components")]
         [HideInInspector] public Kicker kicker;
         [SerializeField] private GameObject holder;
@@ -21,19 +22,37 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
         [SerializeField] private BezierCurve3D toeCurve;
 
         [Header("Properties")]
-        public float dispensedBeat = 0;
-        public bool dispensing;
-        public float hitTimes;
+        public float startBeat;
+        public State state;
+        public float nextAnimBeat;
         public float highKickSwing = 0f;
         private float lastSpriteRot;
         public bool canKick;
-        public GameEvent kicked = new GameEvent();
-        public GameEvent highKicked = new GameEvent();
-        public GameEvent toe = new GameEvent();
         private bool lastKickLeft;
 
-        private void Start()
+        public void Init(Kicker kicker, float dispensedBeat)
         {
+            this.kicker = kicker;
+            kicker.ball = this;
+            kicker.dispenserBeat = dispensedBeat;
+                state = State.Dispensing;
+                startBeat = dispensedBeat;
+                kicker.kickTimes = 0;
+                if (kicker.player)
+                {
+                    MultiSound.Play(new MultiSound.Sound[]
+                    {
+                    new MultiSound.Sound("spaceSoccer/dispenseNoise",   dispensedBeat),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble1", dispensedBeat + 0.25f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble2", dispensedBeat + 0.5f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble2B",dispensedBeat + 0.5f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble3", dispensedBeat + 0.75f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble4", dispensedBeat + 1f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble5", dispensedBeat + 1.25f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble6", dispensedBeat + 1.5f),
+                    new MultiSound.Sound("spaceSoccer/dispenseTumble6B",dispensedBeat + 1.75f),
+                    });
+                }
         }
 
         public void Kick(bool player)
@@ -43,12 +62,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
             lastSpriteRot = spriteHolder.transform.eulerAngles.z;
 
-            dispensing = false;
-            kicked.enabled = true;
-            // kicked.startBeat = Conductor.instance.songPositionInBeats;
-            kicked.startBeat = dispensedBeat + 2 + hitTimes;
-
-            hitTimes++;
+            SetState(State.Kicked);
 
             lastKickLeft = kicker.kickLeft;
 
@@ -67,14 +81,9 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         public void HighKick()
         {
-            hitTimes += GetHighKickLength(false);
-
             lastSpriteRot = spriteHolder.transform.eulerAngles.z;
 
-            dispensing = false;
-            kicked.enabled = false;
-            highKicked.enabled = true;
-            highKicked.startBeat = Conductor.instance.songPositionInBeats;
+            SetState(State.HighKicked);
 
             highKickCurve.KeyPoints[0].transform.position = holder.transform.position;
 
@@ -84,15 +93,10 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         public void Toe()
         {
-            hitTimes += GetHighKickLength(true);
 
             lastSpriteRot = spriteHolder.transform.eulerAngles.z;
 
-            highKicked.enabled = false;
-            kicked.enabled = false;
-
-            toe.enabled = true;
-            toe.startBeat = Conductor.instance.songPositionInBeats;
+            SetState(State.Toe);
 
             toeCurve.KeyPoints[0].transform.position = holder.transform.position;
             if (lastKickLeft)
@@ -110,99 +114,106 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         private void Update()
         {
-            if (dispensing)
+            switch (state)
             {
-                float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(dispensedBeat, 2.35f);
-
-                dispenseCurve.KeyPoints[0].transform.position = new Vector3(kicker.transform.position.x - 6f, kicker.transform.position.y - 6f);
-                dispenseCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 1f, kicker.transform.position.y - 6f);
-
-                holder.transform.localPosition = dispenseCurve.GetPoint(normalizedBeatAnim);
-                spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(0f, -1440f, normalizedBeatAnim));
-
-                /*if (PlayerInput.Pressed())
-                {
-                    if (state.perfect)
+                case State.Dispensing:
                     {
-                        Kick();
+                        float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(startBeat, 2.35f);
+
+                        dispenseCurve.KeyPoints[0].transform.position = new Vector3(kicker.transform.position.x - 6f, kicker.transform.position.y - 6f);
+                        dispenseCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 1f, kicker.transform.position.y - 6f);
+
+                        holder.transform.localPosition = dispenseCurve.GetPoint(normalizedBeatAnim);
+                        spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(0f, -1440f, normalizedBeatAnim));
+
+                        /*if (PlayerInput.Pressed())
+                        {
+                            if (state.perfect)
+                            {
+                                Kick();
+                            }
+                        }*/
+                        break;
                     }
-                }*/
-            }
-            else if (kicked.enabled)
-            {
-                float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(kicked.startBeat, 1.5f);
-
-                if (!lastKickLeft)
-                {
-                    kickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x + 0.5f, kicker.transform.position.y - 6f);
-                    spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot - 360f, normalizedBeatAnim));
-                }
-                else
-                {
-                    kickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 2.5f, kicker.transform.position.y - 6f);
-                    spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot + 360f, normalizedBeatAnim));
-                }
-
-                holder.transform.localPosition = kickCurve.GetPoint(normalizedBeatAnim);
-
-                /*if (PlayerInput.Pressed())
-                {
-                    if (state.perfect)
+                case State.Kicked:
                     {
-                        if (kicker.canHighKick)
+                        float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(startBeat, 1.5f);
+
+                        if (!lastKickLeft)
                         {
-                            HighKick();
+                            kickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x + 0.5f, kicker.transform.position.y - 6f);
+                            spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot - 360f, normalizedBeatAnim));
                         }
-                        else if (kicker.canKick)
+                        else
                         {
-                            Kick();
+                            kickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 2.5f, kicker.transform.position.y - 6f);
+                            spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot + 360f, normalizedBeatAnim));
                         }
-                        // print(normalizedBeat);
+
+                        holder.transform.localPosition = kickCurve.GetPoint(normalizedBeatAnim);
+
+                        /*if (PlayerInput.Pressed())
+                        {
+                            if (state.perfect)
+                            {
+                                if (kicker.canHighKick)
+                                {
+                                    HighKick();
+                                }
+                                else if (kicker.canKick)
+                                {
+                                    Kick();
+                                }
+                                // print(normalizedBeat);
+                            }
+                        }*/
+                        break;
                     }
-                }*/
-            }
-            else if (highKicked.enabled)
-            {
-                float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(highKicked.startBeat, GetHighKickLength(false) + 0.3f);
-
-                highKickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 3.5f, kicker.transform.position.y - 6f);
-
-                holder.transform.localPosition = highKickCurve.GetPoint(normalizedBeatAnim);
-                spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot + 360f, normalizedBeatAnim));
-
-                // if (state.perfect) Debug.Break();
-
-                /*if (PlayerInput.Pressed())
-                {
-                    kickPrepare = true;
-                    kicker.Kick(this);
-                }
-                if (kickPrepare)
-                {
-                    if (PlayerInput.PressedUp())
+                case State.HighKicked:
                     {
-                        if (state.perfect)
+                        float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(startBeat, GetAnimLength(State.HighKicked) + 0.3f);
+
+                        highKickCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 3.5f, kicker.transform.position.y - 6f);
+
+                        holder.transform.localPosition = highKickCurve.GetPoint(normalizedBeatAnim);
+                        spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot + 360f, normalizedBeatAnim));
+
+                        // if (state.perfect) Debug.Break();
+
+                        /*if (PlayerInput.Pressed())
                         {
-                            Toe();
+                            kickPrepare = true;
+                            kicker.Kick(this);
                         }
+                        if (kickPrepare)
+                        {
+                            if (PlayerInput.PressedUp())
+                            {
+                                if (state.perfect)
+                                {
+                                    Toe();
+                                }
+                            }
+                        }*/
+                        break;
                     }
-                }*/
-            }
-            else if (toe.enabled)
-            {
-                float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(toe.startBeat, GetHighKickLength(true) + 0.35f);
+                case State.Toe:
+                    {
+                        float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(startBeat, GetAnimLength(State.Toe) + 0.35f);
 
-                if (!lastKickLeft)
-                {
-                    toeCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x + 0.5f, kicker.transform.position.y - 6f);
-                }
-                else
-                {
-                    toeCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 1.0f, kicker.transform.position.y - 6f);
-                }
+                        if (!lastKickLeft)
+                        {
+                            toeCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x + 0.5f, kicker.transform.position.y - 6f);
+                        }
+                        else
+                        {
+                            toeCurve.KeyPoints[1].transform.position = new Vector3(kicker.transform.position.x - 1.0f, kicker.transform.position.y - 6f);
+                        }
 
-                holder.transform.localPosition = toeCurve.GetPoint(normalizedBeatAnim);
-                spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, -860f, normalizedBeatAnim));
+                        holder.transform.localPosition = toeCurve.GetPoint(normalizedBeatAnim);
+                        spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, -860f, normalizedBeatAnim));
+                        break;
+                    }
             }
 
             holder.transform.position = new Vector3(holder.transform.position.x, holder.transform.position.y, kicker.transform.localPosition.z);
@@ -215,22 +226,28 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
             kickfx.transform.position = holder.transform.position;
         }
 
-        public float GetHighKickLength(bool fromToe)
+        private void SetState(State newState)
         {
-            if (highKickSwing == 0f)
+            state = newState;
+            startBeat = nextAnimBeat;
+            nextAnimBeat += GetAnimLength(newState);
+        }
+
+        public float GetAnimLength(State anim)
+        {
+            switch(anim)
             {
-                return 1.5f;
-            }
-            else
-            {
-                if (fromToe)
-                {
-                    return 2f - (1f - highKickSwing);
-                }
-                else
-                {
+                case State.Dispensing:
+                    return 2f;
+                case State.Kicked:
+                    return 1f;
+                case State.HighKicked:
                     return 2f - highKickSwing;
-                }
+                case State.Toe:
+                    return 2f - (1f - highKickSwing);
+                default:
+                    Debug.LogError("Ball has invalid state. State number: " + (int)anim);
+                    return 0f;
             }
         }
     }

--- a/Assets/Scripts/Games/SpaceSoccer/Kicker.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Kicker.cs
@@ -13,7 +13,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
         public bool canHighKick;
         private bool kickPrepare = false;
         public bool kickLeft;
-        public float dispenserBeat;
+        public float dispenserBeat; //unused
         public int kickTimes = 0;
         public bool player;
 
@@ -40,7 +40,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         public override void OnAce()
         {
-            if (ball.highKicked.enabled)
+            if (ball.state == Ball.State.HighKicked)
             {
                 if (!kickPrepare)
                 {
@@ -83,7 +83,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                     anim.Play("HighKickRight_0", 0, 0);
                 }
             }
-            else if (!highKick)
+            else
             {
                 if (kickLeft)
                 {
@@ -214,106 +214,113 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
             if (ball)
             {
-                if (ball.dispensing)
+                switch (ball.state)
                 {
-                    float normalizedBeat = Conductor.instance.GetPositionFromBeat(ball.dispensedBeat, 2f);
-                    StateCheck(normalizedBeat, !player);
-                    CheckIfFall(normalizedBeat);
-
-                    if (player)
-                    {
-                        if (PlayerInput.Pressed())
+                    case Ball.State.Dispensing:
                         {
-                            if (state.perfect)
-                            {
-                                KickCheck(true);
-                            }
-                            else
-                            {
-                                KickCheck(false, true);
-                            }
-                        }
-                    }
-                }
-                else if (ball.kicked.enabled)
-                {
-                    float normalizedBeat = Conductor.instance.GetPositionFromBeat(ball.kicked.startBeat, 1f);
-                    StateCheck(normalizedBeat, !player);
-                    CheckIfFall(normalizedBeat);
+                            float normalizedBeat = Conductor.instance.GetPositionFromBeat(ball.startBeat, ball.GetAnimLength(Ball.State.Dispensing));
+                            StateCheck(normalizedBeat, !player);
+                            CheckIfFall(normalizedBeat);
 
-                    if (player)
-                    {
-                        if (PlayerInput.Pressed())
-                        {
-                            if (state.perfect)
+                            if (player)
                             {
-                                KickCheck(true);
-                            }
-                            else
-                            {
-                                KickCheck(false, true);
-                            }
-                        }
-                    }
-                }
-                else if (ball.highKicked.enabled)
-                {
-                    float normalizedBeat = Conductor.instance.GetPositionFromMargin(ball.highKicked.startBeat + ball.GetHighKickLength(false), 1f);
-                    if (!kickPrepare)
-                    {
-                        float normalizedBeatPrepare = Conductor.instance.GetPositionFromBeat(ball.highKicked.startBeat, 1f);
-                        StateCheck(normalizedBeatPrepare, !player);
-                        CheckIfFall(normalizedBeat);
-
-                        if (player)
-                        {
-                            if (PlayerInput.AltPressed())
-                            {
-                                Kick(false, true);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        StateCheck(normalizedBeat, !player);
-                        CheckIfFall(normalizedBeat);
-
-                        if (player)
-                        {
-                            if (PlayerInput.AltPressedUp())
-                            {
-                                if (state.perfect)
+                                if (PlayerInput.Pressed())
                                 {
-                                    Toe(true);
-                                }
-                                else
-                                {
-                                    Toe(false);
+                                    if (state.perfect)
+                                    {
+                                        KickCheck(true);
+                                    }
+                                    else
+                                    {
+                                        KickCheck(false, true);
+                                    }
                                 }
                             }
+                            break;
                         }
-                    }
-                }
-                else if (ball.toe.enabled)
-                {
-                    float normalizedBeat = Conductor.instance.GetPositionFromMargin(ball.toe.startBeat + ball.GetHighKickLength(true), 1f);
-                    StateCheck(normalizedBeat, !player);
-                    CheckIfFall(normalizedBeat);
-
-                    if (player)
-                    {
-                        if (PlayerInput.Pressed())
+                    case Ball.State.Kicked:
                         {
-                            if (state.perfect)
+                            float normalizedBeat = Conductor.instance.GetPositionFromBeat(ball.startBeat, ball.GetAnimLength(Ball.State.Kicked));
+                            StateCheck(normalizedBeat, !player);
+                            CheckIfFall(normalizedBeat);
+
+                            if (player)
                             {
-                                KickCheck(true);
+                                if (PlayerInput.Pressed())
+                                {
+                                    if (state.perfect)
+                                    {
+                                        KickCheck(true);
+                                    }
+                                    else
+                                    {
+                                        KickCheck(false, true);
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                    case Ball.State.HighKicked:
+                        {
+                            float normalizedBeat = Conductor.instance.GetPositionFromMargin(ball.startBeat + ball.GetAnimLength(Ball.State.HighKicked), 1f);
+                            if (!kickPrepare)
+                            {
+                                float normalizedBeatPrepare = Conductor.instance.GetPositionFromBeat(ball.startBeat, 1f);
+                                StateCheck(normalizedBeatPrepare, !player);
+                                CheckIfFall(normalizedBeat);
+
+                                if (player)
+                                {
+                                    if (PlayerInput.AltPressed())
+                                    {
+                                        Kick(false, true);
+                                    }
+                                }
                             }
                             else
                             {
-                                KickCheck(false, true);
+                                StateCheck(normalizedBeat, !player);
+                                CheckIfFall(normalizedBeat);
+
+                                if (player)
+                                {
+                                    if (PlayerInput.AltPressedUp())
+                                    {
+                                        if (state.perfect)
+                                        {
+                                            Toe(true);
+                                        }
+                                        else
+                                        {
+                                            Toe(false);
+                                        }
+                                    }
+                                }
                             }
+                            break;
                         }
-                    }
+                    case Ball.State.Toe:
+                        {
+                            float normalizedBeat = Conductor.instance.GetPositionFromMargin(ball.startBeat + ball.GetAnimLength(Ball.State.Toe), 1f);
+                            StateCheck(normalizedBeat, !player);
+                            CheckIfFall(normalizedBeat);
+
+                            if (player)
+                            {
+                                if (PlayerInput.Pressed())
+                                {
+                                    if (state.perfect)
+                                    {
+                                        KickCheck(true);
+                                    }
+                                    else
+                                    {
+                                        KickCheck(false, true);
+                                    }
+                                }
+                            }
+                            break;
+                        }
                 }
             }
             else
@@ -326,6 +333,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                     }
                 }
             }
+
         }
 
         private void KickCheck(bool hit, bool overrideState = false)

--- a/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
@@ -15,7 +15,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
         [SerializeField] private Sprite[] backgroundSprite;
 
         [Header("Properties")]
-        [SerializeField] private bool ballDispensed;
+        [SerializeField] private bool ballDispensed; //unused
 
         public static SpaceSoccer instance { get; private set; }
 

--- a/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
@@ -42,9 +42,7 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
 
         private void Update()
         {
-            if (ballDispensed)
-            {
-            }        
+            
         }
 
         public void Dispense(float beat)
@@ -58,27 +56,10 @@ namespace RhythmHeavenMania.Games.SpaceSoccer
                 ballDispensed = true;
 
                 GameObject ball = Instantiate(ballRef, transform);
+                ball.SetActive(true);
                 Ball ball_ = ball.GetComponent<Ball>();
-                ball_.kicker = kicker;
-                ball_.dispensedBeat = beat;
-                ball_.dispensing = true;
-                kicker.ball = ball_;
-                kicker.dispenserBeat = beat;
-                kicker.kickTimes = 0;
+                ball_.Init(kicker, beat);
             }
-
-            MultiSound.Play(new MultiSound.Sound[]
-            {
-                new MultiSound.Sound("spaceSoccer/dispenseNoise",   beat),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble1", beat + 0.25f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble2", beat + 0.5f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble2B",beat + 0.5f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble3", beat + 0.75f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble4", beat + 1f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble5", beat + 1.25f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble6", beat + 1.5f),
-                new MultiSound.Sound("spaceSoccer/dispenseTumble6B",beat + 1.75f),
-            });
         }
     }
 

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -248,7 +248,7 @@ namespace RhythmHeavenMania
                     new GameAction("keep-up",               delegate { }, 4f, true),
                     new GameAction("high kick-toe!",        delegate { }, 3f, false, new List<Param>() 
                     {
-                        new Param("swing", new EntityTypes.Float(0, 1), "Swing") 
+                        new Param("swing", new EntityTypes.Float(0, 1, 0.5f), "Swing") 
                     }),
                 }),
                 new Minigame("djSchool", "DJ School", "008c97", false, false, new List<GameAction>()


### PR DESCRIPTION
This ONLY fixes the times when you're starting in the middle of a remix. It doesn't fix the time when you place a ball dispense early in a remix that doesn't switch the game (the bug that carson ran into) since it's caused by something else. I'm going to try to fix that bug in the next pull request.