### PR TITLE
Fixed space soccer ball spawning when it shouldn't be

### DIFF
--- a/Assets/Scripts/Games/SpaceSoccer/Ball.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Ball.cs
@@ -9,7 +9,7 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
 {
     public class Ball : MonoBehaviour
     {
-        public enum State { Dispensing, Kicked, HighKicked, Toe };
+        public enum State { None, Dispensing, Kicked, HighKicked, Toe };
         [Header("Components")]
         [HideInInspector] public Kicker kicker;
         [SerializeField] private GameObject holder;
@@ -95,7 +95,7 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
                     }
                 }
             }
-            if(state == 0) //if the for loop didn't set the state
+            if(state == 0) //if the for loop didn't set the state, i.e. all the high kicks happen before the point we start at.
             {
                 //Debug.Log("Defaulting to kicked state");
                 state = State.Kicked;


### PR DESCRIPTION
The soccer ball that is part of the prefab no longer defaults to the Dispensing state (when i refactored the ball script a while ago, i dealt with this problem by just disabling that ball, but this solution should work even with the ball enabled)