### PR TITLE
Prevented out of order initialization

### DIFF
--- a/Assets/Scripts/Games/BlueBear/BlueBear.cs
+++ b/Assets/Scripts/Games/BlueBear/BlueBear.cs
@@ -33,10 +33,6 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Update()
-        {
             headAndBodyAnim.SetBool("ShouldOpenMouth", foodHolder.childCount != 0);
 
             if (PlayerInput.GetAnyDirectionDown())

--- a/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
+++ b/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
@@ -48,13 +48,8 @@ namespace HeavenStudio.Games
             environmentMaterials = environmentRenderer.materials;
             beltMaterial = Instantiate(environmentMaterials[8]);
             environmentMaterials[8] = beltMaterial;
-        }
-
-        
-        void Start()
-        {
             renderQuadTrans.gameObject.SetActive(true);
-            
+
             var cam = GameCamera.instance.camera;
             var camHeight = 2f * cam.orthographicSize;
             var camWidth = camHeight * cam.aspect;

--- a/Assets/Scripts/Games/ClappyTrio/ClappyTrio.cs
+++ b/Assets/Scripts/Games/ClappyTrio/ClappyTrio.cs
@@ -32,7 +32,7 @@ namespace HeavenStudio.Games
             instance = this;
         }
 
-        private void Start()
+        private void InitLions()
         {
             float startPos = -3.066667f;
             float maxWidth = 12.266668f;
@@ -53,6 +53,7 @@ namespace HeavenStudio.Games
                 if (i == lionCount - 1)
                     ClappyTrioPlayer = lion.AddComponent<ClappyTrioPlayer>();
             }
+
         }
 
         private void Update()
@@ -161,7 +162,7 @@ namespace HeavenStudio.Games
             Lion.RemoveRange(1, lionCount - 1);
             lionCount = lions;
             SetFace(0, 0);
-            Start();
+            InitLions();
             PlayAnimationAll("Idle");
         }
 

--- a/Assets/Scripts/Games/ClappyTrio/ClappyTrioPlayer.cs
+++ b/Assets/Scripts/Games/ClappyTrio/ClappyTrioPlayer.cs
@@ -18,7 +18,7 @@ namespace HeavenStudio.Games.Scripts_ClappyTrio
         private GameObject clapEffect;
         new int aceTimes = 0;
 
-        private void Start()
+        private void Awake()
         {
             clapEffect = transform.GetChild(4).GetChild(3).gameObject;
         }

--- a/Assets/Scripts/Games/CropStomp/CropStomp.cs
+++ b/Assets/Scripts/Games/CropStomp/CropStomp.cs
@@ -51,12 +51,8 @@ namespace HeavenStudio.Games
 
         private void Awake()
         {
-            instance = this;
-        }
-
-        private void Start()
-        {
-            // Finding grass sprite width for grass scrolling.
+            instance = this;// Finding grass sprite width for grass scrolling.
+            farmer.Init()
             var grassSprite = grass.sprite;
             var borderLeft = grassSprite.rect.xMin + grassSprite.border.x;
             var borderRight = grassSprite.rect.xMax - grassSprite.border.z;
@@ -295,7 +291,7 @@ namespace HeavenStudio.Games
 
             var veggieX = (beat - startBeat) * -stepDistance / 2f;
             newVeggie.transform.localPosition = new Vector3(veggieX, 0f, 0f);
-
+            newVeggie.Init();
             newVeggie.gameObject.SetActive(true);
         }
         

--- a/Assets/Scripts/Games/CropStomp/Farmer.cs
+++ b/Assets/Scripts/Games/CropStomp/Farmer.cs
@@ -12,7 +12,7 @@ namespace HeavenStudio.Games.Scripts_CropStomp
 
         private CropStomp game;
 
-        private void Start()
+        public void Init()
         {
             game = CropStomp.instance;
         }

--- a/Assets/Scripts/Games/CropStomp/Veggie.cs
+++ b/Assets/Scripts/Games/CropStomp/Veggie.cs
@@ -33,7 +33,7 @@ namespace HeavenStudio.Games.Scripts_CropStomp
 
         private CropStomp game;
 
-        private void Start()
+        public void Init()
         {
             game = CropStomp.instance;
 

--- a/Assets/Scripts/Games/DJSchool/DJSchool.cs
+++ b/Assets/Scripts/Games/DJSchool/DJSchool.cs
@@ -32,11 +32,8 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             djYellowAnim = djYellow.GetComponent<Animator>();
+            student.Init();
         }
 
         private void Update()

--- a/Assets/Scripts/Games/DJSchool/Student.cs
+++ b/Assets/Scripts/Games/DJSchool/Student.cs
@@ -31,7 +31,7 @@ namespace HeavenStudio.Games.Scripts_DJSchool
 
         private DJSchool game;
 
-        private void Start()
+        public void Init()
         {
             game = DJSchool.instance;
             anim = GetComponent<Animator>();

--- a/Assets/Scripts/Games/DrummingPractice/DrummerHit.cs
+++ b/Assets/Scripts/Games/DrummingPractice/DrummerHit.cs
@@ -14,7 +14,7 @@ namespace HeavenStudio.Games.Scripts_DrummingPractice
         private bool hasHit = false;
 
         // Start is called before the first frame update
-        void Start()
+        void Awake()
         {
             PlayerActionInit(gameObject, startBeat);
         }

--- a/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
+++ b/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
@@ -43,10 +43,10 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
+            SetMiis();
         }
-
-        // TODO: Move this to OnGameSwitch() when functional?
-        private void Start()
+        
+        public void OnGameSwitch()
         {
             SetMiis();
         }

--- a/Assets/Scripts/Games/FanClub/FanClub.cs
+++ b/Assets/Scripts/Games/FanClub/FanClub.cs
@@ -62,12 +62,7 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
 
-        const int FAN_COUNT = 12;
-        const float RADIUS = 1.3f;
-        private void Start()
-        {
             Spectators = new List<GameObject>();
             idolAnimator = Arisa.GetComponent<Animator>();
 
@@ -86,14 +81,16 @@ namespace HeavenStudio.Games
             for (int i = 0; i < FAN_COUNT; i++)
             {
                 GameObject mobj = Instantiate(spectator, spectatorAnchor.transform.parent);
+                NtrIdolFan fan = mobj.GetComponent<NtrIdolFan>();
                 mobj.transform.localPosition = new Vector3(spawnPos.x, spawnPos.y, spawnPos.z);
                 mobj.GetComponent<SortingGroup>().sortingOrder = i + sortOrigin;
                 if (i == 3)
                 {
-                    Player = mobj.GetComponent<NtrIdolFan>();
+                    Player = fan;
                     Player.player = true;
                 }
                 Spectators.Add(mobj);
+                fan.Init();
 
                 //prepare spawn point of next spectator
                 spawnPos.x += RADIUS * 2;
@@ -110,6 +107,9 @@ namespace HeavenStudio.Games
                 }
             }
         }
+
+        const int FAN_COUNT = 12;
+        const float RADIUS = 1.3f;
 
         public override void OnGameSwitch(float beat)
         {

--- a/Assets/Scripts/Games/FanClub/NtrIdolFan.cs
+++ b/Assets/Scripts/Games/FanClub/NtrIdolFan.cs
@@ -36,7 +36,7 @@ namespace HeavenStudio.Games.Scripts_FanClub
         private bool inputHit = false;
         private bool hasHit = false;
 
-        public void Start()
+        public void Init()
         {
             if (player)
                 upcomingHits = new Queue<KeyValuePair<float, int>>();    // beat, type

--- a/Assets/Scripts/Games/Fireworks/Fireworks.cs
+++ b/Assets/Scripts/Games/Fireworks/Fireworks.cs
@@ -9,7 +9,7 @@ namespace HeavenStudio.Games
     public class Fireworks : Minigame
     {
         // Start is called before the first frame update
-        void Start()
+        void Awake()
         {
             
         }

--- a/Assets/Scripts/Games/Fireworks/Rocket.cs
+++ b/Assets/Scripts/Games/Fireworks/Rocket.cs
@@ -11,7 +11,7 @@ namespace HeavenStudio.Games.Scripts_Fireworks
         public bool isSparkler;
 
         // Start is called before the first frame update
-        void Start()
+        void Awake()
         {
             
         }

--- a/Assets/Scripts/Games/ForkLifter/ForkLifterPlayer.cs
+++ b/Assets/Scripts/Games/ForkLifter/ForkLifterPlayer.cs
@@ -45,10 +45,6 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             anim = GetComponent<Animator>();
         }
 

--- a/Assets/Scripts/Games/ForkLifter/Pea.cs
+++ b/Assets/Scripts/Games/ForkLifter/Pea.cs
@@ -16,7 +16,7 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
         public int type;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
 

--- a/Assets/Scripts/Games/Global/Flash.cs
+++ b/Assets/Scripts/Games/Global/Flash.cs
@@ -24,7 +24,7 @@ namespace HeavenStudio.Games.Global
 
         private List<Beatmap.Entity> allFadeEvents = new List<Beatmap.Entity>();
 
-        private void Start()
+        private void Awake()
         {
             this.gameObject.transform.SetParent(GameManager.instance.gameObject.transform);
             gameObject.layer = LayerMask.NameToLayer("Flash");

--- a/Assets/Scripts/Games/KarateMan/BarrelDestroyEffect.cs
+++ b/Assets/Scripts/Games/KarateMan/BarrelDestroyEffect.cs
@@ -20,7 +20,7 @@ namespace HeavenStudio.Games.Scripts_KarateMan
 
         public GameObject shadow;
 
-        private void Start()
+        private void Awake()
         {
             SpriteRenderer = this.gameObject.GetComponent<SpriteRenderer>();
             SpriteRenderer.sprite = KarateMan.instance.BarrelSprites[spriteIndex];

--- a/Assets/Scripts/Games/KarateMan/Bomb.cs
+++ b/Assets/Scripts/Games/KarateMan/Bomb.cs
@@ -29,7 +29,7 @@ namespace HeavenStudio.Games.Scripts_KarateMan
         [SerializeField] private AnimationCurve outCurve;
         [SerializeField] private AnimationCurve shadowHitCurve;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
 

--- a/Assets/Scripts/Games/KarateMan/CookingPotDestroyEffect.cs
+++ b/Assets/Scripts/Games/KarateMan/CookingPotDestroyEffect.cs
@@ -17,7 +17,7 @@ namespace HeavenStudio.Games.Scripts_KarateMan
 
         public GameObject pot;
 
-        private void Start()
+        private void Awake()
         {
             SpriteRenderer sr = gameObject.AddComponent<SpriteRenderer>();
             sr.sprite = KarateMan.instance.CookingPotSprites[1];

--- a/Assets/Scripts/Games/KarateMan/Pot.cs
+++ b/Assets/Scripts/Games/KarateMan/Pot.cs
@@ -56,7 +56,7 @@ namespace HeavenStudio.Games.Scripts_KarateMan
 
         private int missTimes = 0;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
             spriteComp = Sprite.GetComponent<SpriteRenderer>();

--- a/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
+++ b/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
@@ -30,10 +30,6 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             canGo = false;
             man.stepTimes = 0;
             SetInterval(0);

--- a/Assets/Scripts/Games/MrUpbeat/UpbeatStep.cs
+++ b/Assets/Scripts/Games/MrUpbeat/UpbeatStep.cs
@@ -14,7 +14,7 @@ namespace HeavenStudio.Games.Scripts_MrUpbeat
         private bool passedFirst = false;
         public float beatOffset = 0;
 
-        private void Start()
+        private void Awake()
         {
             PlayerActionInit(gameObject, startBeat);
         }

--- a/Assets/Scripts/Games/RhythmRally/Paddlers.cs
+++ b/Assets/Scripts/Games/RhythmRally/Paddlers.cs
@@ -15,7 +15,7 @@ namespace HeavenStudio.Games.Scripts_RhythmRally
         private Animator opponentAnim;
         private Conductor cond;
 
-        void Awake()
+        public void Init()
         {
             game = RhythmRally.instance;
             playerAnim = game.playerAnim;

--- a/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
+++ b/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
@@ -55,13 +55,9 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        
-        void Start()
-        {
+            paddlers.Init();
             renderQuadTrans.gameObject.SetActive(true);
-            
+
             var cam = GameCamera.instance.camera;
             var camHeight = 2f * cam.orthographicSize;
             var camWidth = camHeight * cam.aspect;

--- a/Assets/Scripts/Games/RhythmTweezers/Tweezers.cs
+++ b/Assets/Scripts/Games/RhythmTweezers/Tweezers.cs
@@ -18,7 +18,7 @@ namespace HeavenStudio.Games.Scripts_RhythmTweezers
         public SpriteRenderer heldHairSprite;
         public Transform tweezerSpriteTrans;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
             vegetableAnim = RhythmTweezers.instance.VegetableAnimator;

--- a/Assets/Scripts/Games/SpaceSoccer/Ball.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Ball.cs
@@ -168,6 +168,11 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
         {
             switch (state) //handle animations
             {
+                case State.None: //the only time any ball should ever have this state is if it's the unused offscreen ball (which is the only reason this state exists)
+                    {
+                        gameObject.SetActive(false);
+                        break;
+                    }
                 case State.Dispensing:
                     {
                         float normalizedBeatAnim = Conductor.instance.GetPositionFromBeat(startBeat, 2.35f);

--- a/Assets/Scripts/Games/SpaceSoccer/Kicker.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Kicker.cs
@@ -20,22 +20,10 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
         [Header("Components")]
         private Animator anim;
         public Ball ball;
-        public Transform rightLeg;
-        public Transform leftLeg;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
-            GameObject rightLeg = new GameObject();
-            rightLeg.transform.SetParent(this.transform);
-            rightLeg.transform.position = new Vector3(-0.67f, -1.48f);
-
-            GameObject leftLeg = new GameObject("leftLeg");
-            leftLeg.transform.SetParent(this.transform);
-            leftLeg.transform.position = new Vector3(0f, -1.48f);
-
-            this.rightLeg = rightLeg.transform;
-            this.leftLeg = leftLeg.transform;
         }
 
         public override void OnAce()

--- a/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
@@ -24,10 +24,6 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             /*for (int x = 0; x < Random.Range(9, 12); x++)
             {
                 for (int y = 0; y < Random.Range(6, 9); y++)

--- a/Assets/Scripts/Games/Spaceball/Alien.cs
+++ b/Assets/Scripts/Games/Spaceball/Alien.cs
@@ -11,7 +11,7 @@ namespace HeavenStudio.Games.Scripts_Spaceball
         private float showBeat = 0;
         private bool isShowing = false;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
             anim.Play("AlienIdle", 0, 0);

--- a/Assets/Scripts/Games/Spaceball/Spaceball.cs
+++ b/Assets/Scripts/Games/Spaceball/Spaceball.cs
@@ -57,10 +57,6 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             var camEvents = EventCaller.GetAllInGameManagerList("spaceball", new string[] { "camera" });
             List<Beatmap.Entity> tempEvents = new List<Beatmap.Entity>();
             for (int i = 0; i < camEvents.Count; i++)

--- a/Assets/Scripts/Games/Spaceball/SpaceballBall.cs
+++ b/Assets/Scripts/Games/Spaceball/SpaceballBall.cs
@@ -26,7 +26,7 @@ namespace HeavenStudio.Games.Scripts_Spaceball
         public float hitRot;
         public float randomEndPosX;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
 

--- a/Assets/Scripts/Games/Spaceball/SpaceballPlayer.cs
+++ b/Assets/Scripts/Games/Spaceball/SpaceballPlayer.cs
@@ -29,10 +29,6 @@ namespace HeavenStudio.Games.Scripts_Spaceball
         private void Awake()
         {
             instance = this;
-        }
-
-        private void Start()
-        {
             anim = GetComponent<Animator>();
         }
 

--- a/Assets/Scripts/Games/TapTrial/Tap.cs
+++ b/Assets/Scripts/Games/TapTrial/Tap.cs
@@ -11,9 +11,8 @@ namespace HeavenStudio.Games.Scripts_TapTrial
         public float startBeat;
 
         public int type;
-
-        // Start is called before the first frame update
-        void Start()
+        
+        void Awake()
         {
             PlayerActionInit(this.gameObject, startBeat);
         }

--- a/Assets/Scripts/Games/TapTrial/TapTrialPlayer.cs
+++ b/Assets/Scripts/Games/TapTrial/TapTrialPlayer.cs
@@ -12,7 +12,7 @@ namespace HeavenStudio.Games.Scripts_TapTrial
         public float nextBeat;
         public int tripleOffset = 0;
 
-        private void Start()
+        private void Awake()
         {
             anim = GetComponent<Animator>();
         }

--- a/Assets/Scripts/Games/WizardsWaltz/MagicFX.cs
+++ b/Assets/Scripts/Games/WizardsWaltz/MagicFX.cs
@@ -12,7 +12,7 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
         public SpriteRenderer spriteRenderer;
         public GameObject shimmer;
 
-        public void Start()
+        public void Awake()
         {
             int order = (int)Math.Round((transform.position.z - 2) * 1000);
             spriteRenderer.sortingOrder = order;

--- a/Assets/Scripts/Games/WizardsWaltz/Plant.cs
+++ b/Assets/Scripts/Games/WizardsWaltz/Plant.cs
@@ -20,10 +20,6 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
         private void Awake()
         {
             game = WizardsWaltz.instance;
-        }
-
-        private void Start()
-        {
             spriteRenderer.sortingOrder = order;
             animator.Play("Appear", 0, 0);
         }

--- a/Assets/Scripts/Games/WizardsWaltz/Wizard.cs
+++ b/Assets/Scripts/Games/WizardsWaltz/Wizard.cs
@@ -16,7 +16,7 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
         private WizardsWaltz game;
         private float songPos;
 
-        private void Awake()
+        public void Init()
         {
             game = WizardsWaltz.instance;
         }

--- a/Assets/Scripts/Games/WizardsWaltz/WizardsWaltz.cs
+++ b/Assets/Scripts/Games/WizardsWaltz/WizardsWaltz.cs
@@ -34,6 +34,7 @@ namespace HeavenStudio.Games
         private void Awake()
         {
             instance = this;
+            wizard.Init();
         }
 
         private void Start()


### PR DESCRIPTION
I just moved everything that was in start to awake. There are a few other changes I made, like using init functions rather than awake in scripts that depended on something that was initialized in another script's awake (to make sure things always happen in the right order), as well as some other stuff in some specific minigames