### PR TITLE
(minor) Fix for a sound error with Autoplay in Spaceball

### DIFF
--- a/Assets/Scripts/Games/Spaceball/SpaceballBall.cs
+++ b/Assets/Scripts/Games/Spaceball/SpaceballBall.cs
@@ -54,6 +54,12 @@ namespace HeavenStudio.Games.Scripts_Spaceball
             hitRot = Holder.transform.eulerAngles.z;
 
             Jukebox.PlayOneShotGame("spaceball/hit");
+            
+            // jank fix for a bug with autoplay - freeform
+            if (GameManager.instance.autoplay && Conductor.instance.isPlaying && GameManager.instance.canInput)
+            {
+                Jukebox.PlayOneShotGame("spaceball/swing");
+            }
 
             randomEndPosX = Random.Range(40f, 55f);
 


### PR DESCRIPTION
Swing sound is supposed to play any time the batter swings, even when the ball gets hit, but on autoplay it doesn't.