### PR TITLE
Disable GitHub Actions build on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Build my project ✨
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
GitHub Actions blocks repository secrets containing Unity account info required to successfully run the build workflow, so all PR actions will always fail. Because of this, disable builds on PR to reduce unnecessary action runs.

It might be possible to have the action run after a repository owner approves the PR, but I'm not sure if this allows the PR action to use secrets either. Should be easy to test though