### PR TITLE
Internal: Animation speed helper functions

### DIFF
--- a/Assets/Scripts/GameCamera.cs
+++ b/Assets/Scripts/GameCamera.cs
@@ -82,9 +82,12 @@ namespace HeavenStudio
             // this entire thing is a mess redo it later
             //pos
             positionEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "move camera" });
+            // legacy event
+            positionEvents.AddRange(EventCaller.GetAllInGameManagerList("gameManager", new string[] { "move camera" }));
 
             //rot
             rotationEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "rotate camera" });
+            positionEvents.AddRange(EventCaller.GetAllInGameManagerList("gameManager", new string[] { "rotate camera" }));
 
             //scale (TODO)
             // scaleEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "scale camera" });

--- a/Assets/Scripts/Games/PajamaParty/CtrPillowMonkey.cs
+++ b/Assets/Scripts/Games/PajamaParty/CtrPillowMonkey.cs
@@ -58,11 +58,10 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                     else
                         t = jumpPos;
                     Monkey.transform.rotation = Quaternion.Euler(0, 0, Mathf.Lerp(22.5f, -22.5f, t));
-                    anim.Play("MonkeyJump0" + jumpAlt, -1, jumpPos);
+                    anim.DoScaledAnimation("MonkeyJump0" + jumpAlt, startJumpTime, jumpLength);
                 }
                 else
-                    anim.Play("MonkeyJump", -1, jumpPos);
-                anim.speed = 0;
+                    anim.DoScaledAnimation("MonkeyJump", startJumpTime, jumpLength);
             }
             else
             {
@@ -70,8 +69,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 {
                     hasJumped = false;
                     PajamaParty.instance.DoBedImpact();
-                    anim.Play("MonkeyLand", -1, 0);
-                    anim.speed = 1f / cond.pitchedSecPerBeat;
+                    anim.DoScaledAnimationAsync("MonkeyLand");
                     Monkey.transform.rotation = Quaternion.Euler(0, 0, 0);
                     jumpAlt = 0;
                 }
@@ -97,8 +95,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 Projectile.transform.rotation = Quaternion.Euler(0, 0, 0);
                 if (hasThrown)
                 {
-                    anim.Play("MonkeyBeat", -1, 0);
-                    anim.speed = 1f;
+                    anim.DoUnscaledAnimation("MonkeyBeat");
                     Projectile.SetActive(false);
                     hasThrown = false;
                 }
@@ -117,14 +114,12 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
 
         public void Charge(float beat)
         {
-            anim.Play("MonkeyReady", -1, 0);
-            anim.speed = 1f;
+            anim.DoUnscaledAnimation("MonkeyReady");
         }
 
         public void Throw(float beat)
         {
-            anim.Play("MonkeyThrow", -1, 0);
-            anim.speed = 1f;
+            anim.DoUnscaledAnimation("MonkeyThrow");
             startThrowTime = beat;
             Projectile.SetActive(true);
         }
@@ -148,57 +143,25 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
             List<BeatAction.Action> seq = 
                 new List<BeatAction.Action>()
                 {
-                    new BeatAction.Action( beat, delegate { 
-                            anim.Play("MonkeySleep00", -1, 0);
-                            anim.speed = 1f / cond.pitchedSecPerBeat;
-                        }
-                    ),
-                    new BeatAction.Action( beat + 0.5f, delegate { 
-                            anim.Play("MonkeySleep01", -1, 0);
-                            anim.speed = 1f;
-                        }
-                    ),
+                    new BeatAction.Action( beat, delegate { anim.DoScaledAnimationAsync("MonkeySleep00"); }),
+                    new BeatAction.Action( beat + 0.5f, delegate { anim.DoUnscaledAnimation("MonkeySleep01"); }),
                 };
             
             if (col == 0 || col == 4)
             {
-                seq.Add(new BeatAction.Action( beat + 1f, delegate { 
-                        anim.Play("MonkeySleep02", -1, 0);
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
-                    }
-                ));
+                seq.Add(new BeatAction.Action( beat + 1f, delegate { anim.DoScaledAnimationAsync("MonkeySleep02"); }));
             }
             else if (col == 1 || col == 3)
             {
-                seq.Add(new BeatAction.Action( beat + 1.5f, delegate { 
-                        anim.Play("MonkeyReadySleep", -1, 0);
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
-                    }
-                ));
-                seq.Add(new BeatAction.Action( beat + 2.5f, delegate { 
-                        anim.Play("MonkeySleep02", -1, 0);
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
-                    }
-                ));
+                seq.Add(new BeatAction.Action( beat + 1.5f, delegate { anim.DoScaledAnimationAsync("MonkeyReadySleep"); }));
+                seq.Add(new BeatAction.Action( beat + 2.5f, delegate { anim.DoScaledAnimationAsync("MonkeySleep02"); }));
             }
             else
             {
-                seq.Add(new BeatAction.Action( beat + 3f, delegate { 
-                        anim.Play("MonkeyReadySleep", -1, 0);
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
-                    }
-                ));
-                seq.Add(new BeatAction.Action( beat + 4f, delegate { 
-                        anim.Play("MonkeySleep02", -1, 0);
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
-                    }
-                ));
+                seq.Add(new BeatAction.Action( beat + 3f, delegate { anim.DoScaledAnimationAsync("MonkeyReadySleep"); }));
+                seq.Add(new BeatAction.Action( beat + 4f, delegate { anim.DoScaledAnimationAsync("MonkeySleep02"); }));
             }
-            seq.Add(new BeatAction.Action( beat + 7f, delegate { 
-                    anim.Play("MonkeyAwake", -1, 0);
-                    anim.speed = 1f / cond.pitchedSecPerBeat;
-                }
-            ));
+            seq.Add(new BeatAction.Action( beat + 7f, delegate { anim.DoScaledAnimationAsync("MonkeyAwake"); }));
 
             BeatAction.New(Monkey, seq);
         }

--- a/Assets/Scripts/Games/PajamaParty/CtrPillowPlayer.cs
+++ b/Assets/Scripts/Games/PajamaParty/CtrPillowPlayer.cs
@@ -72,8 +72,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 Player.transform.localPosition = new Vector3(0, jumpHeight * yWeight);
                 Shadow.transform.localScale = new Vector3((1f-yWeight*0.2f) * 1.65f, (1f-yWeight*0.2f), 1f);
                 // handles the shirt lifting
-                anim.Play("MakoJump", -1, jumpPos);
-                anim.speed = 0;
+                anim.DoScaledAnimation("MakoJump", startJumpTime, jumpLength);
             }
             else
             {
@@ -84,12 +83,11 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                     hasJumped = false;
                     PajamaParty.instance.DoBedImpact();
                     if (jumpNg)
-                        anim.Play("MakoCatchNg", -1, 0);
+                        anim.DoScaledAnimationAsync("MakoCatchNg");
                     else if (jumpHeight != 4f)
-                        anim.Play("MakoCatch", -1, 0);
+                        anim.DoScaledAnimationAsync("MakoCatch");
                     else
-                        anim.Play("MakoLand", -1, 0);
-                    anim.speed = 1f / cond.pitchedSecPerBeat;
+                        anim.DoScaledAnimationAsync("MakoLand");
                     jumpNg = false;
                 }
                 startJumpTime = Single.MinValue;
@@ -110,8 +108,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 }
                 else
                 {
-                    Projectile.GetComponent<Animator>().Play("ThrowOut", -1, jumpPos);
-                    Projectile.GetComponent<Animator>().speed = 0;
+                    Projectile.GetComponent<Animator>().DoScaledAnimation("ThrowOut", startThrowTime, throwLength);
                 }
                 Projectile.transform.rotation = Quaternion.Euler(0, 0, Projectile.transform.rotation.eulerAngles.z - (360f * Time.deltaTime));
             }
@@ -125,16 +122,15 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 {
                     if (throwNg)
                     {
-                        anim.Play("MakoCatchNg", -1, 0);
+                        anim.DoUnscaledAnimation("MakoCatchNg");
                     }
                     else
                     {
-                        anim.Play("MakoCatch", -1, 0);
+                        anim.DoUnscaledAnimation("MakoCatch");
                     }
                     //TODO: change when locales are a thing
                     Jukebox.PlayOneShotGame("pajamaParty/jp/catch" + UnityEngine.Random.Range(0, 2)); //bruh
 
-                    anim.speed = 1f;
                     Projectile.SetActive(false);
                     hasThrown = false;
                     throwNg = false;
@@ -153,10 +149,9 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
             if (drop)
             {
                 throwType = false;
-                Projectile.GetComponent<Animator>().Play("ThrowOut", -1, 0);
-                Projectile.GetComponent<Animator>().speed = 0;
-                Projectile.transform.rotation = Quaternion.Euler(0, 0, 360f * UnityEngine.Random.Range(0f, 1f));
                 throwLength = 0.5f;
+                Projectile.GetComponent<Animator>().DoScaledAnimation("ThrowOut", startThrowTime, throwLength);
+                Projectile.transform.rotation = Quaternion.Euler(0, 0, 360f * UnityEngine.Random.Range(0f, 1f));
             }
             else
             {
@@ -181,8 +176,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
         public void StartCharge()
         {
             canJump = false;
-            anim.Play("MakoReady");
-            anim.speed = 1f;
+            anim.DoUnscaledAnimation("MakoReady");
             charging = true;
         }
 
@@ -193,22 +187,17 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
             charging = false;
             canCharge = false;
             if (hit)
-            {
-                anim.Play("MakoThrow");
-                anim.speed = 1f; 
-            }
+                anim.DoUnscaledAnimation("MakoThrow");
             else
             {
-                anim.Play("MakoThrowOut");
-                anim.speed = (1f / cond.pitchedSecPerBeat) * 0.5f;
+                anim.DoScaledAnimationAsync("MakoThrowOut", 0.5f);
                 BeatAction.New(Player, new List<BeatAction.Action>()
                 {
                     new BeatAction.Action(
                         beat + 0.5f,
                         delegate { 
-                            anim.Play("MakoPickUp", -1, 0);
+                            anim.DoScaledAnimationAsync("MakoPickUp");
                             Jukebox.PlayOneShotGame("pajamaParty/jp/catch" + UnityEngine.Random.Range(0, 2)); //bruh
-                            anim.speed = 1f / cond.pitchedSecPerBeat;
                             Projectile.SetActive(false);
                             canCharge = true;
                             canJump = true;
@@ -221,8 +210,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
         public void PlayerThrough(float beat)
         {
             var cond = Conductor.instance;
-            anim.Play("MakoThrough", -1, 0);
-            anim.speed = (1f / cond.pitchedSecPerBeat) * 0.5f;
+            anim.DoScaledAnimationAsync("MakoThrough", 0.5f);
             charging = false;
             canCharge = false;
             canJump = false;
@@ -352,8 +340,8 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                     canCharge = true;
                     hasJumped = false;
                     PajamaParty.instance.DoBedImpact();
-                    anim.Play("MakoLand", -1, 0);
-                    anim.speed = 1f / cond.pitchedSecPerBeat;
+
+                    anim.DoScaledAnimationAsync("MakoLand");
                 }
                 startJumpTime = Single.MinValue;
                 Player.transform.localPosition = new Vector3(0, 0);
@@ -363,15 +351,11 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 {
                     new BeatAction.Action(
                         beat,
-                        delegate { anim.Play("MakoSleep00", -1, 0); 
-                            anim.speed = 1f / cond.pitchedSecPerBeat;
-                        }
+                        delegate { anim.DoScaledAnimationAsync("MakoSleep00"); }
                     ),
                     new BeatAction.Action(
                         beat + 0.5f,
-                        delegate { anim.Play("MakoSleep01", -1, 0); 
-                            anim.speed = 1f;
-                        }
+                        delegate { anim.DoUnscaledAnimation("MakoSleep01"); }
                     ),
                     new BeatAction.Action(
                         beat + 1f,
@@ -383,10 +367,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                         beat + 3f,
                         delegate { 
                             if (canSleep)
-                            {
-                                anim.Play(alt ? "MakoReadySleep01" : "MakoReadySleep", -1, 0); 
-                                anim.speed = 1f / cond.pitchedSecPerBeat;
-                            }
+                                anim.DoScaledAnimationAsync(alt ? "MakoReadySleep01" : "MakoReadySleep");
                         }
                     ),
                     new BeatAction.Action(
@@ -407,23 +388,18 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                     caller.CanHit(false);
                     canSleep = false;
                     if (state <= -1f || state >= 1f)
-                    {
-                        anim.Play("MakoSleepNg", -1, 0);
-                    }
+                        anim.DoUnscaledAnimation("MakoSleepNg");
                     else
                     {
                         Jukebox.PlayOneShotGame("pajamaParty/siesta4");
-                        anim.Play("MakoSleepJust", -1, 0); 
-                        anim.speed = 1f / cond.pitchedSecPerBeat;
+                        anim.DoScaledAnimationAsync("MakoSleepJust");
 
                         BeatAction.New(Player, new List<BeatAction.Action>()
                         {
                             new BeatAction.Action(
                                 caller.startBeat + 7f,
                                 delegate { 
-                                    anim.Play("MakoAwake", -1, 0);
-                                    anim.speed = 1f / cond.pitchedSecPerBeat;
-
+                                    anim.DoScaledAnimationAsync("MakoAwake");
                                     Jukebox.PlayOneShotGame("pajamaParty/siestaDone");
                                 }
                             ),
@@ -437,8 +413,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 var cond = Conductor.instance;
                 if (canSleep)
                 {
-                    anim.Play("MakoSleepThrough", -1, 0);
-                    anim.speed = 1f / cond.pitchedSecPerBeat;
+                    anim.DoScaledAnimationAsync("MakoSleepThrough", -1, 0);
                     caller.CanHit(false);
                     canSleep = false;
                 }
@@ -449,9 +424,7 @@ namespace HeavenStudio.Games.Scripts_PajamaParty
                 var cond = Conductor.instance;
                 if (canSleep)
                 {
-                    anim.Play("MakoSleepOut", -1, 0);
-                    anim.speed = (1f / cond.pitchedSecPerBeat) * 0.5f;
-
+                    anim.DoScaledAnimationAsync("MakoSleepOut", 0.5f);
                     Jukebox.PlayOneShotGame("pajamaParty/siestaBad");
                     caller.CanHit(false);
                     canSleep = false;

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using DG.Tweening;
 
 using HeavenStudio.Util;
-
+using HeavenStudio.Editor.Track;
 using HeavenStudio.Games;
 
 using System;
@@ -121,7 +121,7 @@ namespace HeavenStudio
                 new Minigame("gameManager", "Game Manager", "", false, true, new List<GameAction>()
                 {
                     new GameAction("switchGame",            delegate { GameManager.instance.SwitchGame(eventCaller.currentSwitchGame, eventCaller.currentEntity.beat); }, 0.5f, inactiveFunction: delegate { GameManager.instance.SwitchGame(eventCaller.currentSwitchGame, eventCaller.currentEntity.beat); }),
-                    new GameAction("end",                   delegate { Debug.Log("end"); }),
+                    new GameAction("end",                   delegate { Debug.Log("end"); GameManager.instance.Stop(0); Timeline.instance?.SetTimeButtonColors(true, false, false);}),
                     new GameAction("skill star",            delegate {  }, 1f, true),
                     new GameAction("flash",                 delegate 
                     {

--- a/Assets/Scripts/Util/AnimationHelpers.cs
+++ b/Assets/Scripts/Util/AnimationHelpers.cs
@@ -9,5 +9,64 @@ namespace HeavenStudio.Util
             float compare = anim.GetCurrentAnimatorStateInfo(0).speed;
             return anim.GetCurrentAnimatorStateInfo(0).normalizedTime >= compare && !anim.IsInTransition(0);
         }
+
+        /// <summary>
+        /// Sets animator's progress on an animation based on current song beat between startTime and length
+        /// function must be called in actor's Update loop to update properly
+        /// </summary>
+        /// <param name="anim">Animator to update</param>
+        /// <param name="animName">name of animation to play</param>
+        /// <param name="startTime">reference start time of animation (progress 0.0)</param>
+        /// <param name="length">duration of animation (progress 1.0)</param>
+        /// <param name="timeScale">multiplier for animation progress (smaller values make animation slower)</param>
+        /// <param name="animLayer">animator layer to play animation on</param>
+        public static void DoScaledAnimation(this Animator anim, string animName, float startTime, float length = 1f, float timeScale = 1f, int animLayer = -1)
+        {
+            float pos = Conductor.instance.GetPositionFromBeat(startTime, length) * timeScale;
+            anim.Play(animName, animLayer, pos);
+            anim.speed = 0;
+        }
+
+        /// <summary>
+        /// Sets animator progress on an animation according to pos
+        /// </summary>
+        /// <param name="anim">Animator to update</param>
+        /// <param name="animName">name of animation to play</param>
+        /// <param name="pos">position to set animation progress to (0.0 - 1.0)</param>
+        /// <param name="animLayer">animator layer to play animation on</param>
+        public static void DoNormalizedAnimation(this Animator anim, string animName, float pos = 0f, int animLayer = -1)
+        {
+            anim.Play(animName, animLayer, pos);
+            anim.speed = 0;
+        }
+
+        /// <summary>
+        /// Plays animation on animator, scaling speed to song BPM
+        /// call this funtion once, when playing an animation
+        /// </summary>
+        /// <param name="anim">Animator to play animation on</param>
+        /// <param name="animName">name of animation to play</param>
+        /// <param name="timeScale">multiplier for animation speed</param>
+        /// <param name="startPos">starting progress of animation</param>
+        /// <param name="animLayer">animator layer to play animation on</param>
+        public static void DoScaledAnimationAsync(this Animator anim, string animName, float timeScale = 1f, float startPos = 0f, int animLayer = -1)
+        {
+            anim.Play(animName, animLayer, startPos);
+            anim.speed = (1f / Conductor.instance.pitchedSecPerBeat) * timeScale;
+        }
+
+        /// <summary>
+        /// Plays animation on animator, at default speed
+        /// this is the least nessecary function here lol
+        /// </summary>
+        /// <param name="anim">Animator to play animation on</param>
+        /// <param name="animName">name of animation to play</param>
+        /// <param name="startPos">starting progress of animation</param>
+        /// <param name="animLayer">animator layer to play animation on</param>
+        public static void DoUnscaledAnimation(this Animator anim, string animName, float startPos = 0f, int animLayer = -1)
+        {
+            anim.Play(animName, animLayer, startPos);
+            anim.speed = 1f;
+        }
     }
 }


### PR DESCRIPTION
examples in Pajama Party's code
also makes remixes stop when the "end" entity is reached, allows (deprecated) loading of the old camera entities