### PR TITLE
Second PlayerActionEvent Pass

### DIFF
--- a/Assets/Scripts/Games/CropStomp/Veggie.cs
+++ b/Assets/Scripts/Games/CropStomp/Veggie.cs
@@ -223,7 +223,7 @@ namespace HeavenStudio.Games.Scripts_CropStomp
 
             stompedBeat = cond.songPositionInBeats;
 
-            landBeat = targetBeat + (float)cond.BeatsToSecs(Minigame.EndTime()-1, cond.GetBpmAtBeat(targetBeat));
+            landBeat = targetBeat + (float)cond.SecsToBeats(Minigame.EndTime()-1, cond.GetBpmAtBeat(targetBeat));
 
             if (autoTriggered)
             {

--- a/Assets/Scripts/Games/Minigame.cs
+++ b/Assets/Scripts/Games/Minigame.cs
@@ -249,5 +249,12 @@ namespace HeavenStudio.Games
             Debug.LogWarning($"Sound sequence {name} not found in game {game} (did you build AssetBundles?)");
             return null;
         }
+
+        private void OnDestroy() {
+            foreach (var evt in scheduledInputs)
+            {
+                evt.Disable();
+            }
+        }
     }
 }

--- a/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
+++ b/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
@@ -28,7 +28,8 @@ namespace HeavenStudio.Games.Loaders
                 new GameAction("toss ball", "Toss Ball")
                 {
                     function = delegate { RhythmRally.instance.Toss(eventCaller.currentEntity.beat, eventCaller.currentEntity.length, 6f, true); }, 
-                    defaultLength = 2f
+                    defaultLength = 2f, 
+                    resizable = true
                 },
                 new GameAction("rally", "Rally")
                 {
@@ -375,16 +376,16 @@ namespace HeavenStudio.Games
             switch (rallySpeed)
             {
                 case RallySpeed.Normal:
-                    targetBeat = serveBeat + 2f;
+                    targetBeat = 2f;
                     bounceBeat = serveBeat + 1f;
                     break;
                 case RallySpeed.Fast:
                 case RallySpeed.SuperFast:
-                    targetBeat = serveBeat + 1f;
+                    targetBeat = 1f;
                     bounceBeat = serveBeat + 0.5f;
                     break;
                 case RallySpeed.Slow:
-                    targetBeat = serveBeat + 4f;
+                    targetBeat = 4f;
                     bounceBeat = serveBeat + 2f;
                     break;
             }
@@ -393,13 +394,16 @@ namespace HeavenStudio.Games
             MultiSound.Play(new MultiSound.Sound[] { new MultiSound.Sound("rhythmRally/Serve", serveBeat), new MultiSound.Sound("rhythmRally/ServeBounce", bounceBeat) });
             paddlers.BounceFX(bounceBeat);
 
-            paddlers.ResetState();
+            ScheduleInput(serveBeat, targetBeat, InputType.STANDARD_DOWN, paddlers.Just, paddlers.Miss, paddlers.Out);
         }
 
         public void Toss(float beat, float length, float height, bool firstToss = false)
         {
             // Hide trail while tossing to prevent weirdness while teleporting ball.
             ballTrail.gameObject.SetActive(false);
+
+            if (firstToss)
+                height *= length/2f;
 
             tossCurve.transform.localScale = new Vector3(1f, height, 1f);
             tossBeat = beat;

--- a/Assets/Scripts/Games/RhythmTweezers/Hair.cs
+++ b/Assets/Scripts/Games/RhythmTweezers/Hair.cs
@@ -21,24 +21,12 @@ namespace HeavenStudio.Games.Scripts_RhythmTweezers
             tweezers = game.Tweezers;
         }
 
+        private void Start() {
+            game.ScheduleInput(createBeat, game.tweezerBeatOffset + game.beatInterval, InputType.STANDARD_DOWN | InputType.DIRECTION_DOWN, Just, Miss, Out);
+        }
+
         private void Update()
         {
-            if (plucked) return;
-
-            float stateBeat = Conductor.instance.GetPositionFromMargin(createBeat + game.tweezerBeatOffset + game.beatInterval, 1f);
-            StateCheck(stateBeat);
-
-            if (PlayerInput.Pressed(true))
-            {
-                if (state.perfect)
-                {
-                    Ace();
-                }
-                else if (state.notPerfect())
-                {
-                    Miss();
-                }
-            }
         }
 
         public void Ace()
@@ -48,16 +36,27 @@ namespace HeavenStudio.Games.Scripts_RhythmTweezers
             plucked = true;
         }
 
-        public void Miss()
+        public void NearMiss()
         {
             tweezers.Pluck(false, this);
             tweezers.hitOnFrame++;
             plucked = true;
         }
 
-        public override void OnAce()
+        private void Just(PlayerActionEvent caller, float state)
         {
+            if (state >= 1f || state <= -1f) {
+                NearMiss();
+                return; 
+            }
             Ace();
         }
+
+        private void Miss(PlayerActionEvent caller) 
+        {
+            // this is where perfect challenge breaks
+        }
+
+        private void Out(PlayerActionEvent caller) {}
     }
 }

--- a/Assets/Scripts/Games/SpaceSoccer/Ball.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/Ball.cs
@@ -27,7 +27,8 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
         public float nextAnimBeat;
         public float highKickSwing = 0f;
         private float lastSpriteRot;
-        public bool canKick; //unused
+        public bool canKick;
+        public bool waitKickRelease;
         private bool lastKickLeft;
 
         public void Init(Kicker kicker, float dispensedBeat)
@@ -182,14 +183,6 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
 
                         holder.transform.localPosition = dispenseCurve.GetPoint(normalizedBeatAnim);
                         spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(0f, -1440f, normalizedBeatAnim));
-
-                        /*if (PlayerInput.Pressed())
-                        {
-                            if (state.perfect)
-                            {
-                                Kick();
-                            }
-                        }*/
                         break;
                     }
                 case State.Kicked:
@@ -208,22 +201,6 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
                         }
 
                         holder.transform.localPosition = kickCurve.GetPoint(normalizedBeatAnim);
-
-                        /*if (PlayerInput.Pressed())
-                        {
-                            if (state.perfect)
-                            {
-                                if (kicker.canHighKick)
-                                {
-                                    HighKick();
-                                }
-                                else if (kicker.canKick)
-                                {
-                                    Kick();
-                                }
-                                // print(normalizedBeat);
-                            }
-                        }*/
                         break;
                     }
                 case State.HighKicked:
@@ -234,24 +211,6 @@ namespace HeavenStudio.Games.Scripts_SpaceSoccer
 
                         holder.transform.localPosition = highKickCurve.GetPoint(normalizedBeatAnim);
                         spriteHolder.transform.eulerAngles = new Vector3(0, 0, Mathf.Lerp(lastSpriteRot, lastSpriteRot + 360f, normalizedBeatAnim));
-
-                        // if (state.perfect) Debug.Break();
-
-                        /*if (PlayerInput.Pressed())
-                        {
-                            kickPrepare = true;
-                            kicker.Kick(this);
-                        }
-                        if (kickPrepare)
-                        {
-                            if (PlayerInput.PressedUp())
-                            {
-                                if (state.perfect)
-                                {
-                                    Toe();
-                                }
-                            }
-                        }*/
                         break;
                     }
                 case State.Toe:

--- a/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
@@ -116,6 +116,7 @@ namespace HeavenStudio.Games
                 {
                     DispenseSound(beat);
                 }
+                kicker.DispenseBall(beat);
 
                 kicker.canKick = true;
             }

--- a/Assets/Scripts/Games/WizardsWaltz/Plant.cs
+++ b/Assets/Scripts/Games/WizardsWaltz/Plant.cs
@@ -24,6 +24,10 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
             animator.Play("Appear", 0, 0);
         }
 
+        private void Start() {
+            game.ScheduleInput(createBeat, game.beatInterval, InputType.STANDARD_DOWN | InputType.DIRECTION_DOWN, Just, Miss, Out);
+        }
+
         private void Update()
         {
             if (!passed && Conductor.instance.songPositionInBeats > createBeat + game.beatInterval)
@@ -31,23 +35,6 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
                 StartCoroutine(FadeOut());
                 passed = true;
             }
-
-            if (hit) return;
-
-            float stateBeat = Conductor.instance.GetPositionFromMargin(createBeat + game.beatInterval, 1f);
-            StateCheck(stateBeat);
-
-            if (PlayerInput.Pressed(true))
-            {
-                if (state.perfect)
-                {
-                    Ace();
-                } else if (state.notPerfect())
-                {
-                    Miss();
-                }
-            }
-
         }
 
         public void Bloom()
@@ -81,16 +68,27 @@ namespace HeavenStudio.Games.Scripts_WizardsWaltz
             hit = true;
         }
 
-        public void Miss()
+        public void NearMiss()
         {
             game.wizard.Magic(this, false);
             hit = true;
         }
 
-        public override void OnAce()
+        private void Just(PlayerActionEvent caller, float state)
         {
+            if (state >= 1f || state <= -1f) {
+                NearMiss();
+                return; 
+            }
             Ace();
         }
+
+        private void Miss(PlayerActionEvent caller) 
+        {
+            // this is where perfect challenge breaks
+        }
+
+        private void Out(PlayerActionEvent caller) {}
 
         public IEnumerator FadeOut()
         {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -51,7 +51,7 @@ PlayerSettings:
   m_MTRendering: 1
   mipStripping: 0
   numberOfMipsStripped: 0
-  m_StackTraceTypes: 020000000200000002000000020000000200000001000000
+  m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0


### PR DESCRIPTION
## Playback
Updated the following minigames to use PlayerActionEvent for hit detection:
- Space Soccer
- Spaceball
- Rhythm Rally
- Rhythm Tweezers
- Wizard's Waltz (Mahou Tsukai)

Fixed bug in Crop Stomp where queued inputs would carry over between games switches (technical: PlayerActionEvent objects now clean themselves up on every game switch)